### PR TITLE
add link back to source code

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ If your distro doesn't support the available packages you can dowload and compil
 ## Runing and building the app
 You can run or build App Outlet by yourself. You can build in Linux, Windows or Mac OS but the software install features will work only in linux systems.
 
+### App source code
+#### Step 0: viewing source code
+Feel free to view the github repo here: [https://github.com/app-outlet/app-outlet](https://github.com/app-outlet/app-outlet)
+
 ### Setting up the project
 #### Step 1: Installing system dependencies
 You will need the following tools:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ![Banner](https://github.com/app-outlet/app-outlet/raw/master/src/assets/banner.png)
-    
+
 ## App Outlet  | [![Build Status](https://travis-ci.org/app-outlet/app-outlet.svg?branch=master)](https://travis-ci.org/app-outlet/app-outlet)
 
 App Outlet is a Universal application store inspired by the Linux App Store online service. It allows you to easily search and download [W.I.P] applications that run on most Linux distributions. It currently works with AppImages, Flatpaks and Snaps.
@@ -18,7 +18,7 @@ You can also get the unpacked version here:
 
 [![Get unpacked version](https://github.com/app-outlet/app-outlet/raw/master/src/assets/unpacked.png)](https://appoutlet.herokuapp.com/download/unpacked)
 
-If your distro doesn't support the available packages you can dowload and compile the source code following the instructions below. 
+If your distro doesn't support the available packages you can dowload and compile the source code following the instructions below.
 
 ## Who is talking about us?
 - [Diolinux (in portuguese)](https://www.diolinux.com.br/2019/10/app-outlet-o-sucessor-do-linux-app-store-loja-snap-appimage-flatpak.html)
@@ -28,7 +28,7 @@ If your distro doesn't support the available packages you can dowload and compil
 
 
 ## Runing and building the app
-You can run or build App Outlet by yourself. You can build in Linux, Windows or Mac OS but the software install features will work only in linux systems. 
+You can run or build App Outlet by yourself. You can build in Linux, Windows or Mac OS but the software install features will work only in linux systems.
 
 ### Setting up the project
 #### Step 1: Installing system dependencies
@@ -59,7 +59,7 @@ npm run start
 npm run electron:linux
 ```
 This command will generate:
-- An AppImage file 
+- An AppImage file
 - A .deb file
 - A .snap file
 - A folder `linux-unpacked` folder with the unpacked app
@@ -71,4 +71,3 @@ This command will generate:
 ## Third part stuff:
 - Icon made by [martz90](https://www.deviantart.com/martz90) from [deviantart.com](https://www.deviantart.com/martz90/art/Light-Icons-Pack-379943080)
 - Initial project started using [angular-electron boilerplate](https://github.com/maximegris/angular-electron)
-


### PR DESCRIPTION
I didn't see any url back to the main github page, so I though that it would be useful to have a link back to the source code instead of having to copy the url from the `git clone` command and then paste in your browser.

if you want to make any alteration/have a different view of how you want to link back, then please let me know and I will update the pull request if you want. Just let me know :grin:

thank you for this project, it is awesome!